### PR TITLE
Improved error message for `setColor(color)` when `color` is undefined or not a string

### DIFF
--- a/src/tcwidget/ledbutton.ts
+++ b/src/tcwidget/ledbutton.ts
@@ -125,6 +125,9 @@ export class LedButton extends TCWidget {
   // ToDo: create color names map
   private hexColorFromString = (color: string): number => {
     // parse hex or decimal color value from string
+    if (!(color && typeof color == 'string')) {
+      throw Error(`No valid color given, received ${typeof color}`);
+    }
     const colval = color.startsWith('#') ? parseInt(color.slice(1), 16) : parseInt(color);
     if (isNaN(colval)) {
       // ToDo: lookup color value from color names map


### PR DESCRIPTION
Prior to this the error message is
```
TypeError: Cannot read property 'startsWith' of undefined
    at LedButton.hexColorFromString (A:\_Source\makehaus-tests\node_modules\@makeproaudio\makehaus-js\dist\index.js:762:34)
    at LedButton.setColor (A:\_Source\makehaus-tests\node_modules\@makeproaudio\makehaus-js\dist\index.js:783:23)
    at LedButton.<anonymous> (A:\_Source\makehaus-tests\index.ts:35:23)
    at LedButton.emit (events.js:314:20)
    at Object.next (A:\_Source\makehaus-tests\node_modules\@makeproaudio\makehaus-js\dist\index.js:838:24)
    at SafeSubscriber.__tryOrUnsub (A:\_Source\makehaus-tests\node_modules\rxjs\src\internal\Subscriber.ts:265:10)
    at SafeSubscriber.next (A:\_Source\makehaus-tests\node_modules\rxjs\src\internal\Subscriber.ts:207:14)
    at Subscriber._next (A:\_Source\makehaus-tests\node_modules\rxjs\src\internal\Subscriber.ts:139:22)
    at Subscriber.next (A:\_Source\makehaus-tests\node_modules\rxjs\src\internal\Subscriber.ts:99:12)
    at FilterSubscriber._next (A:\_Source\makehaus-tests\node_modules\rxjs\src\internal\operators\filter.ts:101:24)        
[ERROR] 16:21:13 TypeError: Cannot read property 'startsWith' of undefined
```
Now the error message is more descriptive:
```
Error: No valid color given, received undefined
    at LedButton.hexColorFromString (A:\_Source\makehaus-js\dist\index.js:763:23)
    at LedButton.setColor (A:\_Source\makehaus-js\dist\index.js:786:23)
    at LedButton.<anonymous> (A:\_Source\makehaus-tests\index.ts:35:23)
    at LedButton.emit (events.js:314:20)
    at Object.next (A:\_Source\makehaus-js\dist\index.js:841:24)
    at SafeSubscriber.__tryOrUnsub (A:\_Source\makehaus-js\node_modules\rxjs\src\internal\Subscriber.ts:265:10)
    at SafeSubscriber.next (A:\_Source\makehaus-js\node_modules\rxjs\src\internal\Subscriber.ts:207:14)
    at Subscriber._next (A:\_Source\makehaus-js\node_modules\rxjs\src\internal\Subscriber.ts:139:22)
    at Subscriber.next (A:\_Source\makehaus-js\node_modules\rxjs\src\internal\Subscriber.ts:99:12)
    at FilterSubscriber._next (A:\_Source\makehaus-js\node_modules\rxjs\src\internal\operators\filter.ts:101:24)
[ERROR] 16:56:06 Error: No valid color given, received undefined
```